### PR TITLE
Fix error on Keyword.merge for Watcher.Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Bella can be installed by adding `bella` to your list of dependencies in `mix.ex
 ```elixir
 def deps do
   [
-    {:bella, "~> 0.0.5"}
+    {:bella, "~> 0.0.6"}
   ]
 end
 ```

--- a/lib/bella/watcher/core.ex
+++ b/lib/bella/watcher/core.ex
@@ -13,7 +13,7 @@ defmodule Bella.Watcher.Core do
         } = _s
       ) do
     client.watch(conn, watcher.operation(),
-      params: %{resourceVersion: rv},
+      params: [resourceVersion: rv],
       stream_to: pid,
       recv_timeout: watch_timeout
     )

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Bella.MixProject do
   use Mix.Project
-  @version "0.0.5"
+  @version "0.0.6"
   @source_url "https://github.com/batteries-included/bella"
 
   def project do


### PR DESCRIPTION
K8s.Client.Runner.Watch.run calls Keyword.merge which doesn't like
params being a map